### PR TITLE
fix: use `npx cdktf-cli` in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ jobs:
         run: yarn install
 
       - name: Generate module and provider bindings
-        run: npx cdktf get
+        run: npx cdktf-cli get
 
       # Remove this step if you don't have any
       - name: Run unit tests
@@ -80,7 +80,7 @@ jobs:
         run: yarn install
 
       - name: Generate module and provider bindings
-        run: npx cdktf get
+        run: npx cdktf-cli get
 
       # Remove this step if you don't have any
       - name: Run unit tests


### PR DESCRIPTION
Because `npx cdktf` causes `npm ERR! could not determine executable to run`

It looks like `--yes` flag is not needed because `cdktf-cli` is [installed as global here](https://github.com/hashicorp/terraform-cdk-action/blob/main/src/action.ts#L78), correct?
