### PR TITLE
chore: notify Slack on successful GH release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,3 +66,13 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_REF: ${{ github.ref }}
         run: errout=$(mktemp); gh release create $(cat dist/releasetag.txt) -R $GITHUB_REPOSITORY -F dist/changelog.md -t $(cat dist/releasetag.txt) --target $GITHUB_REF 2> $errout && true; exitcode=$?; if [ $exitcode -ne 0 ] && ! grep -q "Release.tag_name already exists" $errout; then cat $errout; exit $exitcode; fi
+  release_notification:
+    needs: release_github
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        with:
+          payload: '{"repository":"terraform-cdk-action","version":"${{ git describe --tags }}"}'


### PR DESCRIPTION
This allows us to send a reminder message to our maintainers to update the Marketplace, which unfortunately has to happen manually; there is no way to automate it.

Fixes #42 albeit somewhat hackily - unfortunately there's not much else we can do without GitHub exposing an API or CLI command for updating the Marketplace.