### PR TITLE
chore: switch to monthly dependency updates

### DIFF
--- a/.github/workflows/upgrade-main.yml
+++ b/.github/workflows/upgrade-main.yml
@@ -4,7 +4,7 @@ name: upgrade-main
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 0 0 * * *
+    - cron: 0 0 1 * *
 jobs:
   upgrade:
     name: Upgrade

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -5,6 +5,7 @@
 
 import { TextFile } from "projen";
 import { JobPermission } from "projen/lib/github/workflows-model";
+import { UpgradeDependenciesSchedule } from "projen/lib/javascript";
 import {
   GitHubActionTypeScriptProject,
   RunsUsing,
@@ -94,6 +95,7 @@ const project = new GitHubActionTypeScriptProject({
   depsUpgradeOptions: {
     workflowOptions: {
       labels: ["automerge", "dependencies"],
+      schedule: UpgradeDependenciesSchedule.MONTHLY,
     },
   },
   workflowGitIdentity: {


### PR DESCRIPTION
Because of the issue in #42 and the hacky solution in #45 it does not make sense to do nightly updates, especially when it's usually just Projen that gets updated and nothing else.

We could do weekly but I think monthly makes even more sense for this project.