### PR TITLE
chore: add issue templates

### DIFF
--- a/.copywrite.hcl
+++ b/.copywrite.hcl
@@ -11,7 +11,10 @@ project {
     # "vendors/**",
     # "**autogen**",
     "**/node_modules/**",
+    ".github/ISSUE_TEMPLATE/**",
+    "coverage/**",
+    "dist/**",
+    "test-reports/**",
     "action.yml",
-    "dist/**"
   ]
 }

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,126 @@
+name: "🐛 Bug Report"
+description: "If something isn't working as expected 🤔"
+title: "COMPONENT: short issue description"
+labels: [bug, new]
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ⬆️⬆️ Don't forget to update the issue title! ⬆️⬆️
+
+  - type: markdown
+    attributes:
+      value: |
+        **Note**
+        We use GitHub issues for tracking bugs and enhancements. For questions, please use [the community forum](https://discuss.hashicorp.com/c/terraform-core/cdk-for-terraform/47) where there are more people ready to help.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: |
+        A clear and concise description of the issue in plain English.
+        Feel free to include screenshots, but do NOT paste your full debug output here; link that in a GitHub Gist further down in this form.
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: GitHub Action Version
+      description: |
+        What version of this GitHub Action are you using?
+      placeholder: v0.1.25
+    validations:
+      required: true
+
+  - type: textarea
+    id: configuration
+    attributes:
+      label: Configuration
+      description: |
+        What input options are you using for the action? You can directly copy/paste what's in your workflow file.
+        (NOTE: Please redact any secrets or other sensitive information!)
+      placeholder: |
+        terraformVersion: 1.4.6
+        cdktfVersion: 0.16.3
+        stackName: my-stack
+        mode: plan-only
+        terraformCloudToken: ${{ secrets.TF_API_TOKEN }}
+        githubToken: ${{ secrets.GITHUB_TOKEN }}
+    validations:
+      required: true
+
+  - type: input
+    id: gist
+    attributes:
+      label: Gist
+      description: |
+        If possible, please provide a link to a [GitHub Gist](https://gist.github.com/) containing your complete debug output or anything else that would be helpful for reproducing your issue.
+      placeholder: |
+        https://gist.github.com/gdb/b6365e79be6052e7531e7ba6ea8caf23
+    validations:
+      required: false
+
+  - type: textarea
+    id: solutions
+    attributes:
+      label: Possible Solutions
+      description: |
+        Do you have any ideas or suggestions for how the issue might be resolved?
+    validations:
+      required: false
+
+  - type: textarea
+    id: workarounds
+    attributes:
+      label: Workarounds
+      description: |
+        Did you discover any workarounds on your own? If so, please list them here.
+    validations:
+      required: false
+
+  - type: textarea
+    id: miscellaneous
+    attributes:
+      label: Anything Else?
+      description: |
+        Is there anything else we should know? For example, is there anything atypical about your setup that could be affecting this issue?
+    validations:
+      required: false
+
+  - type: textarea
+    id: references
+    attributes:
+      label: References
+      description: |
+        Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Or links to documentation pages?
+        Guide to referencing Github issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests
+      placeholder: |
+        - #123
+        - #456
+        - https://developer.hashicorp.com/terraform/cdktf/create-and-deploy/deployment-patterns
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: contribution
+    attributes:
+      label: Help Wanted
+      description: Is this something you're able to or interested in helping out with? This is not required but a helpful way to signal to us that you're planning to open a PR with a fix.
+      options:
+        - label: I'm interested in contributing a fix myself
+          required: false
+
+  - type: textarea
+    id: community
+    attributes:
+      label: Community Note
+      description: Please do not remove, edit, or change the following note for our community. Just leave everything in this textbox as-is.
+      value: |
+        - Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
+        - Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request
+        - If you are interested in working on this issue or have submitted a pull request, please leave a comment
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: ❓ Question
+    url: https://discuss.hashicorp.com/c/terraform-core/cdk-for-terraform/47
+    about: 🙋 For usage questions that may not require a core maintainer to answer, post in our community forum
+  - name: Terraform Cloud/Enterprise Troubleshooting
+    url: https://support.hashicorp.com/hc/en-us/requests/new
+    about: For issues related to the Terraform Cloud/Enterprise platform, please submit a HashiCorp support request or email tf-cloud@hashicorp.support

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,59 @@
+name: "📕 Documentation Issue"
+description: "👀 Report an issue with the README, Marketplace page, or other docs related to this Action"
+title: "COMPONENT: short issue description"
+labels: [documentation, new]
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ⬆️⬆️ Don't forget to update the issue title! ⬆️⬆️
+
+  - type: markdown
+    attributes:
+      value: |
+        **Note**
+        We use GitHub issues for tracking bugs and enhancements. For questions, please use [the community forum](https://discuss.hashicorp.com/c/terraform-core/cdk-for-terraform/47) where there are more people ready to help.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of the issue in plain English.
+    validations:
+      required: true
+
+  - type: textarea
+    id: links
+    attributes:
+      label: Links
+      description: |
+        Include links to affected or related documentation page(s) or issues.
+        Guide to referencing Github issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests
+      placeholder: |
+        - https://developer.hashicorp.com/terraform/cdktf/create-and-deploy/deployment-patterns
+        - #123
+        - #456
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: contribution
+    attributes:
+      label: Help Wanted
+      description: Is this something you're able to or interested in helping out with? This is not required but a helpful way to signal to us that you're planning to open a PR with a fix.
+      options:
+        - label: I'm interested in contributing a fix myself
+          required: false
+
+  - type: textarea
+    id: community
+    attributes:
+      label: Community Note
+      description: Please do not remove, edit, or change the following note for our community. Just leave everything in this textbox as-is.
+      value: |
+        - Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
+        - Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request
+        - If you are interested in working on this issue or have submitted a pull request, please leave a comment
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,59 @@
+name: "🚀 Feature Request"
+description: "I have a suggestion (and might want to implement myself 🙂)"
+title: "COMPONENT: short feature request description"
+labels: [enhancement, new]
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ⬆️⬆️ Don't forget to update the issue title! ⬆️⬆️
+
+  - type: markdown
+    attributes:
+      value: |
+        **Note**
+        We use GitHub issues for tracking bugs and enhancements. For questions, please use [the community forum](https://discuss.hashicorp.com/c/terraform-core/cdk-for-terraform/47) where there are more people ready to help.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of the feature request in plain English.
+    validations:
+      required: true
+
+  - type: textarea
+    id: references
+    attributes:
+      label: References
+      description: |
+        Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Or links to documentation pages?
+        Guide to referencing Github issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests
+      placeholder: |
+        - #123
+        - #456
+        - https://developer.hashicorp.com/terraform/cdktf/create-and-deploy/deployment-patterns
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: contribution
+    attributes:
+      label: Help Wanted
+      description: Is this something you're able to or interested in helping out with? This is not required but a helpful way to signal to us that you're planning to open a PR with a fix.
+      options:
+        - label: I'm interested in contributing a fix myself
+          required: false
+
+  - type: textarea
+    id: community
+    attributes:
+      label: Community Note
+      description: Please do not remove, edit, or change the following note for our community. Just leave everything in this textbox as-is.
+      value: |
+        - Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
+        - Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request
+        - If you are interested in working on this issue or have submitted a pull request, please leave a comment
+    validations:
+      required: true


### PR DESCRIPTION
As we're starting to see more activity in this repo, especially community contributors coming in, I figured these are good to have.

FWIW I looked into whether there is a Projen-native way to generate issue templates and there's not (there only is for the pull request template), and translating our existing YAML templates into JavaScript so that Projen can compile it back into YAML seems silly. So, just adding in the YAML files and having them not be managed by Projen at all seemed like the best solution. IMO this also makes them easier to maintain in the future (for example, if we want to add a new field to an issue template in all our repos). But if anyone disagrees with this approach, let me know.