### PR TITLE
chore: have GitHub releases use the Projen token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
         continue-on-error: true
       - name: Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PROJEN_GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_REF: ${{ github.ref }}
         run: errout=$(mktemp); gh release create $(cat dist/releasetag.txt) -R $GITHUB_REPOSITORY -F dist/changelog.md -t $(cat dist/releasetag.txt) --target $GITHUB_REF 2> $errout && true; exitcode=$?; if [ $exitcode -ne 0 ] && ! grep -q "Release.tag_name already exists" $errout; then cat $errout; exit $exitcode; fi

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -264,5 +264,10 @@ releaseWorkflow?.addOverride("on.push", {
     ".github/**/*.md",
   ],
 });
+// The below is necessary in order to allow the git-tags workflow to run
+releaseWorkflow?.addOverride(
+  "jobs.release_github.steps.3.env.GITHUB_TOKEN",
+  "${{ secrets.PROJEN_GITHUB_TOKEN }}"
+);
 
 project.synth();


### PR DESCRIPTION
This is necessary in order to allow the git-tags workflow to run.