### PR TITLE
chore: fix node version used in custom workflows

### DIFF
--- a/.github/workflows/upgrade-cdktf.yml
+++ b/.github/workflows/upgrade-cdktf.yml
@@ -18,6 +18,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
+      - name: Setup Node.js
+        uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d
+        with:
+          node-version: 20.9.0
       - name: Install
         run: yarn install
       - name: Get current CDKTF version

--- a/.github/workflows/upgrade-node-manually.yml
+++ b/.github/workflows/upgrade-node-manually.yml
@@ -20,6 +20,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
+      - name: Setup Node.js
+        uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d
+        with:
+          node-version: 20.9.0
       - name: Install
         run: yarn install
       - name: Get current Node.js version

--- a/.github/workflows/upgrade-node.yml
+++ b/.github/workflows/upgrade-node.yml
@@ -18,6 +18,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
+      - name: Setup Node.js
+        uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d
+        with:
+          node-version: 20.9.0
       - name: Install
         run: yarn install
       - name: Get current Node.js version

--- a/.github/workflows/upgrade-terraform.yml
+++ b/.github/workflows/upgrade-terraform.yml
@@ -18,6 +18,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
+      - name: Setup Node.js
+        uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d
+        with:
+          node-version: 20.9.0
       - name: Install
         run: yarn install
       - name: Get current Terraform version

--- a/projenrc/upgrade-cdktf.ts
+++ b/projenrc/upgrade-cdktf.ts
@@ -46,6 +46,13 @@ export class UpgradeCDKTF {
             uses: "actions/checkout@v3",
           },
           {
+            name: "Setup Node.js",
+            uses: "actions/setup-node@v3",
+            with: {
+              "node-version": project.minNodeVersion,
+            },
+          },
+          {
             name: "Install",
             run: "yarn install",
           },

--- a/projenrc/upgrade-node.ts
+++ b/projenrc/upgrade-node.ts
@@ -42,6 +42,13 @@ export class UpgradeNode {
         uses: "actions/checkout@v3",
       },
       {
+        name: "Setup Node.js",
+        uses: "actions/setup-node@v3",
+        with: {
+          "node-version": project.minNodeVersion,
+        },
+      },
+      {
         name: "Install",
         run: "yarn install",
       },

--- a/projenrc/upgrade-terraform.ts
+++ b/projenrc/upgrade-terraform.ts
@@ -47,6 +47,13 @@ export class UpgradeTerraform {
             uses: "actions/checkout@v3",
           },
           {
+            name: "Setup Node.js",
+            uses: "actions/setup-node@v3",
+            with: {
+              "node-version": project.minNodeVersion,
+            },
+          },
+          {
             name: "Install",
             run: "yarn install",
           },


### PR DESCRIPTION
These workflows started failing after #101 got merged because the Node version on the GHA runners is 18, and this package now expects 20.