### PR TITLE
chore(test): run integration tests on pull_request_target

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,6 +1,6 @@
 name: integration-tests
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - ready_for_review


### PR DESCRIPTION
Otherwise Dependabot can't access the TFC API token in secrets.
