### PR TITLE
chore(deps): update pinned versions of GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,14 +18,3 @@ updates:
       - security
     # Disable version updates for npm dependencies, only use Dependabot for security updates
     open-pull-requests-limit: 0
-  - package-ecosystem: github-actions
-    directory: /
-    schedule:
-      interval: daily
-    labels:
-      - auto-approve
-      - automerge
-      - dependencies
-    # only update hashicorp actions, external actions managed by tsccr
-    allow:
-      - dependency-name: hashicorp/*

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -14,12 +14,13 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pull-requests: write
     env:
       PR_ID: ${{ github.event.pull_request.number }}
     if: contains(github.event.pull_request.labels.*.name, 'auto-approve') && github.event.pull_request.draft == false
     steps:
       - name: Checkout PR
-        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
@@ -28,10 +29,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.PROJEN_GITHUB_TOKEN }}
         run: gh pr review ${{ github.event.pull_request.number }} --approve
-      - name: Post a note explaining we can't auto-approve PRs by team-tf-cdk
+      - name: Auto-approve PRs by team-tf-cdk as github-actions[bot]
         if: github.event.pull_request.user.login == 'team-tf-cdk'
         env:
-          GH_TOKEN: ${{ secrets.PROJEN_GITHUB_TOKEN }}
-        run: |-
-          gh pr comment $PR_ID --body "Since I authored this PR, I can't approve it myself, sorry! Someone else will need to approve it."
-          gh pr edit $PR_ID --remove-label "auto-approve"
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr review ${{ github.event.pull_request.number }} --approve

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -18,7 +18,7 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'automerge') && !contains(github.event.pull_request.labels.*.name, 'do-not-merge') && github.event.pull_request.draft == false
     steps:
       - name: Checkout
-        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29
       - name: Turn on automerge for this PR by a trusted user or bot
         if: github.event.pull_request.user.login == 'team-tf-cdk' || contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association) || github.actor == 'dependabot[bot]'
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
       CI: "true"
     steps:
       - name: Checkout
-        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
@@ -28,7 +28,7 @@ jobs:
       - name: build
         run: npx projen build
       - name: Setup Copywrite tool
-        uses: hashicorp/setup-copywrite@867a1a2a064a0626db322392806428f7dc59cb3e
+        uses: hashicorp/setup-copywrite@32638da2d4e81d56a0764aa1547882fc4d209636
       - name: Add headers using Copywrite tool
         run: copywrite headers
       - name: Find mutations
@@ -56,7 +56,7 @@ jobs:
     if: always() && needs.build.outputs.self_mutation_happened && !(github.event.pull_request.head.repo.full_name != github.repository)
     steps:
       - name: Checkout
-        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29
         with:
           token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
           ref: ${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/git-tags.yml
+++ b/.github/workflows/git-tags.yml
@@ -13,7 +13,7 @@ jobs:
       contents: write
     steps:
       - name: git checkout
-        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29
         with:
           fetch-depth: 0
       - id: get_aliases

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       CI: "true"
     steps:
       - name: Checkout
-        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29
         with:
           fetch-depth: 0
       - name: Set git identity
@@ -81,7 +81,7 @@ jobs:
       contents: read
     steps:
       - name: git checkout
-        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29
         with:
           fetch-depth: 0
       - name: Get the latest tag (version) from git

--- a/.github/workflows/upgrade-cdktf.yml
+++ b/.github/workflows/upgrade-cdktf.yml
@@ -17,7 +17,7 @@ jobs:
       CHECKPOINT_DISABLE: "1"
     steps:
       - name: Checkout
-        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29
         with:
           fetch-depth: 0
       - name: Setup Node.js

--- a/.github/workflows/upgrade-main.yml
+++ b/.github/workflows/upgrade-main.yml
@@ -15,7 +15,7 @@ jobs:
       patch_created: ${{ steps.create_patch.outputs.patch_created }}
     steps:
       - name: Checkout
-        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29
         with:
           ref: main
       - name: Setup Node.js
@@ -46,7 +46,7 @@ jobs:
     if: ${{ needs.upgrade.outputs.patch_created }}
     steps:
       - name: Checkout
-        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29
         with:
           ref: main
       - name: Download patch
@@ -77,7 +77,7 @@ jobs:
             *Automatically created by projen via the "upgrade-main" workflow*
           branch: github-actions/upgrade-main
           title: "chore(deps): upgrade dependencies"
-          labels: automerge,dependencies
+          labels: automerge,auto-approve,dependencies
           body: |-
             Upgrades project dependencies. See details in [workflow run].
 

--- a/.github/workflows/upgrade-node-manually.yml
+++ b/.github/workflows/upgrade-node-manually.yml
@@ -19,7 +19,7 @@ jobs:
       CHECKPOINT_DISABLE: "1"
     steps:
       - name: Checkout
-        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29
       - name: Setup Node.js
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8
         with:

--- a/.github/workflows/upgrade-node.yml
+++ b/.github/workflows/upgrade-node.yml
@@ -17,7 +17,7 @@ jobs:
       CHECKPOINT_DISABLE: "1"
     steps:
       - name: Checkout
-        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29
       - name: Setup Node.js
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8
         with:

--- a/.github/workflows/upgrade-terraform.yml
+++ b/.github/workflows/upgrade-terraform.yml
@@ -17,7 +17,7 @@ jobs:
       CHECKPOINT_DISABLE: "1"
     steps:
       - name: Checkout
-        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29
         with:
           fetch-depth: 0
       - name: Setup Node.js

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -6,7 +6,7 @@
 import { TerraformCdkActionProject } from "./projenrc";
 
 const githubActionPinnedVersions = {
-  "actions/checkout": "0ad4b8fadaa221de15dcec353f45205ec38ea70b", // v4.1.4
+  "actions/checkout": "a5ac7e51b41094c92402da3b24376905380afc29", // v4.1.6
   "actions/download-artifact": "65a9edc5881444af0b9093a5e628f2fe47ea3b2e", // v4.1.7
   "actions/github-script": "60a0d83039c74a4aee543508d2ffcb1c3799cdea", // v7.0.1
   "actions/setup-node": "60edb5dd545a775178f52524783378180af0d1f8", // v4.0.2

--- a/projenrc/auto-approve.ts
+++ b/projenrc/auto-approve.ts
@@ -25,9 +25,6 @@ export class AutoApprove {
       "${{ github.workflow }}-${{ github.head_ref }}";
 
     const maintainerStatuses = `fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]')`;
-    const commentText =
-      '"Since I authored this PR, I can\'t approve it myself, sorry! Someone else will need to approve it."';
-
     workflow.addJobs({
       approve: {
         runsOn: ["ubuntu-latest"],
@@ -54,19 +51,17 @@ export class AutoApprove {
             },
           },
           {
-            name: "Post a note explaining we can't auto-approve PRs by team-tf-cdk",
+            name: "Auto-approve PRs by team-tf-cdk as github-actions[bot]",
             if: "github.event.pull_request.user.login == 'team-tf-cdk'",
-            run:
-              "gh pr comment $PR_ID --body " +
-              commentText +
-              '\ngh pr edit $PR_ID --remove-label "auto-approve"',
+            run: "gh pr review ${{ github.event.pull_request.number }} --approve",
             env: {
-              GH_TOKEN: "${{ secrets.PROJEN_GITHUB_TOKEN }}",
+              GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}",
             },
           },
         ],
         permissions: {
           contents: JobPermission.READ,
+          pullRequests: JobPermission.WRITE,
         },
       },
     });

--- a/projenrc/index.ts
+++ b/projenrc/index.ts
@@ -62,7 +62,7 @@ export class TerraformCdkActionProject extends GitHubActionTypeScriptProject {
       mergify: false,
       depsUpgradeOptions: {
         workflowOptions: {
-          labels: ["automerge", "dependencies"],
+          labels: ["automerge", "auto-approve", "dependencies"],
           schedule: UpgradeDependenciesSchedule.WEEKLY,
         },
       },
@@ -170,7 +170,7 @@ import * as core from "@actions/core";`,
     this.buildWorkflow?.addPostBuildSteps(
       {
         name: "Setup Copywrite tool",
-        uses: "hashicorp/setup-copywrite@867a1a2a064a0626db322392806428f7dc59cb3e", // v1.1.2
+        uses: "hashicorp/setup-copywrite@32638da2d4e81d56a0764aa1547882fc4d209636", // v1.1.3
       },
       { name: "Add headers using Copywrite tool", run: "copywrite headers" }
     );


### PR DESCRIPTION
This also adds the ability for the github-actions bot user to approve PRs, now that that's enabled on this org.