### PR TITLE
chore(ci): fix syntax for concurrency in workflows

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -8,7 +8,8 @@ on:
       - labeled
       - ready_for_review
       - reopened
-concurrency: ${{ github.workflow }}-${{ github.head_ref }}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
 jobs:
   approve:
     runs-on: ubuntu-latest

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -9,7 +9,8 @@ on:
       - ready_for_review
       - reopened
       - synchronize
-concurrency: ${{ github.workflow }}-${{ github.head_ref }}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
 jobs:
   automerge:
     runs-on: ubuntu-latest

--- a/.github/workflows/upgrade-cdktf.yml
+++ b/.github/workflows/upgrade-cdktf.yml
@@ -5,7 +5,8 @@ on:
   schedule:
     - cron: 11 */6 * * *
   workflow_dispatch: {}
-concurrency: ${{ github.workflow }}-${{ github.ref }}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   upgrade:
     name: Upgrade CDKTF

--- a/.github/workflows/upgrade-node.yml
+++ b/.github/workflows/upgrade-node.yml
@@ -5,7 +5,8 @@ on:
   schedule:
     - cron: 13 7 * * *
   workflow_dispatch: {}
-concurrency: ${{ github.workflow }}-${{ github.ref }}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   upgrade:
     name: Upgrade Node.js

--- a/.github/workflows/upgrade-terraform.yml
+++ b/.github/workflows/upgrade-terraform.yml
@@ -5,7 +5,8 @@ on:
   schedule:
     - cron: 39 23 * * 0
   workflow_dispatch: {}
-concurrency: ${{ github.workflow }}-${{ github.ref }}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   upgrade:
     name: Upgrade Terraform

--- a/projenrc/auto-approve.ts
+++ b/projenrc/auto-approve.ts
@@ -21,8 +21,9 @@ export class AutoApprove {
       },
     });
 
-    (workflow.concurrency as any) =
-      "${{ github.workflow }}-${{ github.head_ref }}";
+    (workflow.concurrency as any) = {
+      group: "${{ github.workflow }}-${{ github.head_ref }}",
+    };
 
     const maintainerStatuses = `fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]')`;
     workflow.addJobs({

--- a/projenrc/automerge.ts
+++ b/projenrc/automerge.ts
@@ -27,8 +27,9 @@ export class Automerge {
       },
     });
 
-    (workflow.concurrency as any) =
-      "${{ github.workflow }}-${{ github.head_ref }}";
+    (workflow.concurrency as any) = {
+      group: "${{ github.workflow }}-${{ github.head_ref }}",
+    };
 
     const maintainerStatuses = `fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]')`;
     workflow.addJobs({

--- a/projenrc/upgrade-cdktf.ts
+++ b/projenrc/upgrade-cdktf.ts
@@ -20,7 +20,9 @@ export class UpgradeCDKTF {
       workflowDispatch: {}, // allow manual triggering
     });
 
-    (workflow.concurrency as any) = "${{ github.workflow }}-${{ github.ref }}";
+    (workflow.concurrency as any) = {
+      group: "${{ github.workflow }}-${{ github.ref }}",
+    };
 
     const createPRbase: JobStep = {
       uses: "peter-evans/create-pull-request@v3",

--- a/projenrc/upgrade-node.ts
+++ b/projenrc/upgrade-node.ts
@@ -33,8 +33,9 @@ export class UpgradeNode {
       },
     });
 
-    (autoWorkflow.concurrency as any) =
-      "${{ github.workflow }}-${{ github.ref }}";
+    (autoWorkflow.concurrency as any) = {
+      group: "${{ github.workflow }}-${{ github.ref }}",
+    };
 
     const commonSteps: JobStep[] = [
       {

--- a/projenrc/upgrade-terraform.ts
+++ b/projenrc/upgrade-terraform.ts
@@ -20,7 +20,9 @@ export class UpgradeTerraform {
       workflowDispatch: {}, // allow manual triggering
     });
 
-    (workflow.concurrency as any) = "${{ github.workflow }}-${{ github.ref }}";
+    (workflow.concurrency as any) = {
+      group: "${{ github.workflow }}-${{ github.ref }}",
+    };
 
     const createPRbase: JobStep = {
       uses: "peter-evans/create-pull-request@v3",


### PR DESCRIPTION
While this project uses a very old version of Projen under-the-hood that doesn't get updated often, I want to make sure we future-proof our code for if/when it does get updated, so our workflows don't break like they did for our other projects.