### PR TITLE
chore(deps): upgrade action-docs to v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,24 +2,24 @@
 
 The Terraform CDK GitHub Action allows you to run CDKTF as part of your CI/CD workflow.
 
-<!-- action-docs-inputs -->
+<!-- action-docs-inputs action="action.yml" -->
 ## Inputs
 
-| parameter | description | required | default |
+| name | description | required | default |
 | --- | --- | --- | --- |
-| cdktfVersion | The version of CDKTF to use | `false` | 0.20.11 |
-| terraformVersion | The version of Terraform to use | `false` | 1.10.5 |
-| workingDirectory | The directory to use for the project | `false` | ./ |
-| mode | What action to take: `synth-only` runs only the synthesis, `plan-only` only runs a plan, `auto-approve-apply` runs a plan and then performs an apply, `auto-approve-destroy` runs a plan and then performs a destroy | `true` |  |
-| stackName | The stack to run / plan, only required when the mode is `plan-only` or `plan-and-apply` | `false` |  |
-| terraformCloudToken | The Terraform Cloud / Terraform Enterprise token to use | `false` |  |
-| githubToken | The github token to use | `false` |  |
-| commentOnPr | Whether to comment the plan / the status on the PR | `false` | true |
-| updateComment | Whether to update the last comment on the PR rather than adding a new comment | `false` | true |
-| customNpxArgs | The additional CLI arguments to pass to npx as part of the cdktf-cli execution. | `false` |  |
-| cdktfArgs | The additional CLI arguments to pass to cdktf as part of the cdktf-cli execution. | `false` |  |
-| suppressOutput | Whether to suppress the output of the action in PR comments | `false` | false |
-<!-- action-docs-inputs -->
+| `cdktfVersion` | <p>The version of CDKTF to use</p> | `false` | `0.20.11` |
+| `terraformVersion` | <p>The version of Terraform to use</p> | `false` | `1.10.5` |
+| `workingDirectory` | <p>The directory to use for the project</p> | `false` | `./` |
+| `mode` | <p>What action to take: <code>synth-only</code> runs only the synthesis, <code>plan-only</code> only runs a plan, <code>auto-approve-apply</code> runs a plan and then performs an apply, <code>auto-approve-destroy</code> runs a plan and then performs a destroy</p> | `true` | `""` |
+| `stackName` | <p>The stack to run / plan, only required when the mode is <code>plan-only</code> or <code>plan-and-apply</code></p> | `false` | `""` |
+| `terraformCloudToken` | <p>The Terraform Cloud / Terraform Enterprise token to use</p> | `false` | `""` |
+| `githubToken` | <p>The github token to use</p> | `false` | `""` |
+| `commentOnPr` | <p>Whether to comment the plan / the status on the PR</p> | `false` | `true` |
+| `updateComment` | <p>Whether to update the last comment on the PR rather than adding a new comment</p> | `false` | `true` |
+| `customNpxArgs` | <p>The additional CLI arguments to pass to npx as part of the cdktf-cli execution.</p> | `false` | `""` |
+| `cdktfArgs` | <p>The additional CLI arguments to pass to cdktf as part of the cdktf-cli execution.</p> | `false` | `""` |
+| `suppressOutput` | <p>Whether to suppress the output of the action in PR comments</p> | `false` | `false` |
+<!-- action-docs-inputs action="action.yml" -->
 
 ## Example Configurations
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@typescript-eslint/eslint-plugin": "^8",
     "@typescript-eslint/parser": "^8",
     "@vercel/ncc": "^0.38.3",
-    "action-docs": "^1.2.0",
+    "action-docs": "^2.5.0",
     "commit-and-tag-version": "^12",
     "constructs": "10.3.0",
     "eslint": "^9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1182,16 +1182,17 @@ acorn@^8.11.0, acorn@^8.14.0, acorn@^8.4.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.14.0.tgz#063e2c70cac5fb4f6467f0b11152e04c682795b0"
   integrity sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==
 
-action-docs@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/action-docs/-/action-docs-1.2.0.tgz#b7c932aed32b227f2e536d84e77db50e38c99762"
-  integrity sha512-qSyslpGvLfrUSmYqFthlCcSbUCkDe4sr4Q3/imnUFwaH5gdD94WO+bjY4AfYJB2iBf+iNs0JYHU8UpCpnjSodg==
+action-docs@^2.5.0:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/action-docs/-/action-docs-2.5.1.tgz#6ec3ab8bb5e8f33ccbc34a3d879a797c0d814baf"
+  integrity sha512-kACC20UOsuVifAEYZAAMsm+Lpq14nWXM3FDbIUqUiu7s3KtlGSfRG5btboYIGNomZQ5coTc/UR1F5H9yRqTAEw==
   dependencies:
-    chalk "^4.1.0"
-    figlet "^1.5.0"
-    js-yaml "^4.0.0"
-    replace-in-file "^6.3.5"
-    yargs "^17.6.0"
+    chalk "^5.3.0"
+    figlet "^1.7.0"
+    replace-in-file "^7.1.0"
+    showdown "^2.1.0"
+    yaml "^2.3.4"
+    yargs "^17.7.2"
 
 add-stream@^1.0.0:
   version "1.0.0"
@@ -1605,13 +1606,18 @@ chalk@^2.4.2:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@^4.0.0, chalk@^4.0.2, chalk@^4.1.0, chalk@^4.1.2:
+chalk@^4.0.0, chalk@^4.0.2, chalk@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
+
+chalk@^5.3.0:
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.4.1.tgz#1b48bf0963ec158dce2aacf69c093ae2dd2092d8"
+  integrity sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==
 
 char-regex@^1.0.2:
   version "1.0.2"
@@ -1686,6 +1692,11 @@ combined-stream@^1.0.8:
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
   dependencies:
     delayed-stream "~1.0.0"
+
+commander@^9.0.0:
+  version "9.5.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-9.5.0.tgz#bc08d1eb5cedf7ccb797a96199d41c7bc3e60d30"
+  integrity sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==
 
 comment-json@4.2.2:
   version "4.2.2"
@@ -2525,7 +2536,7 @@ fdir@^6.4.2:
   resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.4.3.tgz#011cdacf837eca9b811c89dbb902df714273db72"
   integrity sha512-PMXmW2y1hDDfTSRc9gaXIuCCRpuoz3Kaz8cUelp3smouvfT632ozg2vrT6lJsHKKOF59YLbOGfAWGUcKEfRMQw==
 
-figlet@^1.5.0:
+figlet@^1.7.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/figlet/-/figlet-1.8.0.tgz#1b93c4f65f4c1a3b1135221987eee8cf8b9c0ac7"
   integrity sha512-chzvGjd+Sp7KUvPHZv6EXV5Ir3Q7kYNpCr4aHrRW79qFtTefmQZNny+W1pW9kf5zeE6dikku2W50W/wAH2xWgw==
@@ -2771,7 +2782,7 @@ glob-parent@^6.0.2:
   dependencies:
     is-glob "^4.0.3"
 
-glob@^7.0.0, glob@^7.1.3, glob@^7.1.4, glob@^7.2.0:
+glob@^7.0.0, glob@^7.1.3, glob@^7.1.4:
   version "7.2.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
   integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
@@ -2783,7 +2794,7 @@ glob@^7.0.0, glob@^7.1.3, glob@^7.1.4, glob@^7.2.0:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^8:
+glob@^8, glob@^8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/glob/-/glob-8.1.0.tgz#d388f656593ef708ee3e34640fdfb99a9fd1c33e"
   integrity sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==
@@ -3710,7 +3721,7 @@ js-yaml@3.14.1, js-yaml@^3.13.1:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
-js-yaml@^4.0.0, js-yaml@^4.1.0:
+js-yaml@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
   integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
@@ -4569,14 +4580,14 @@ repeat-string@^1.6.1:
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
   integrity sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==
 
-replace-in-file@^6.3.5:
-  version "6.3.5"
-  resolved "https://registry.yarnpkg.com/replace-in-file/-/replace-in-file-6.3.5.tgz#ff956b0ab5bc96613207d603d197cd209400a654"
-  integrity sha512-arB9d3ENdKva2fxRnSjwBEXfK1npgyci7ZZuwysgAp7ORjHSyxz6oqIjTEv8R0Ydl4Ll7uOAZXL4vbkhGIizCg==
+replace-in-file@^7.1.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/replace-in-file/-/replace-in-file-7.2.0.tgz#bd66f97202ae2196fc9126d3bceab1dda68b7cc2"
+  integrity sha512-CiLXVop3o8/h2Kd1PwKPPimmS9wUV0Ki6Fl8+1ITD35nB3Gl/PrW5IONpTE0AXk0z4v8WYcpEpdeZqMXvSnWpg==
   dependencies:
     chalk "^4.1.2"
-    glob "^7.2.0"
-    yargs "^17.2.1"
+    glob "^8.1.0"
+    yargs "^17.7.2"
 
 require-directory@^2.1.1:
   version "2.1.1"
@@ -4757,6 +4768,13 @@ shelljs@^0.8.5:
     glob "^7.0.0"
     interpret "^1.0.0"
     rechoir "^0.6.2"
+
+showdown@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/showdown/-/showdown-2.1.0.tgz#1251f5ed8f773f0c0c7bfc8e6fd23581f9e545c5"
+  integrity sha512-/6NVYu4U819R2pUIk79n67SYgJHWCce0a5xTP979WbNp0FL9MN1I1QK662IDU1b6JzKTvmhgI7T7JYIxBi3kMQ==
+  dependencies:
+    commander "^9.0.0"
 
 shx@^0.3.4:
   version "0.3.4"
@@ -5507,7 +5525,7 @@ yallist@^4.0.0:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
-yaml@^2.2.2, yaml@^2.4.1:
+yaml@^2.2.2, yaml@^2.3.4, yaml@^2.4.1:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.7.0.tgz#aef9bb617a64c937a9a748803786ad8d3ffe1e98"
   integrity sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==
@@ -5535,7 +5553,7 @@ yargs@^16.2.0:
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
 
-yargs@^17.2.1, yargs@^17.3.1, yargs@^17.6.0, yargs@^17.7.2:
+yargs@^17.3.1, yargs@^17.7.2:
   version "17.7.2"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.2.tgz#991df39aca675a192b816e1e0363f9d75d2aa269"
   integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==


### PR DESCRIPTION
As I was working on #261, the other package flagged by `yarn outdated` as being behind on upgrades was `action-docs`, so I figured I might as well update that too if I'm going through and manually updating things.